### PR TITLE
Fixed CMD arg in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:latest
+FROM node:15.11.0-stretch
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install
 EXPOSE 3030
 
-CMD ("node", "server.js")
+CMD ["node", "server.js"]

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,13 @@
+# Readme.md
+
+* Building the image
+
+```bash
+docker build -t letsconnect .
+```
+
+* Run the container and expose it on port 3030
+
+```bash
+docker run -d --rm -p 3030:3030 --name letsconnect letsconnect
+```


### PR DESCRIPTION
The Docker file CMD argument had () rather than [].

Also, I added a readme for examples on how to run the container.